### PR TITLE
Change to bind to support unix sockets

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,22 @@
-Rails:
-  Enabled: true
 AllCops:
+  TargetRubyVersion: 2.3
   Exclude:
     - db/migrate/*
     - db/schema.rb
-  TargetRubyVersion: 2.3
-Documentation:
+
+Rails:
+  Enabled: true
+
+Style/Documentation:
   Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - config/routes.rb
+    - config/initializers/app_config.rb
+    - spec/**/*.rb
+    - lib/tasks/*
+
+Rails/Output:
+  Exclude:
+  - db/seeds.rb

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'coffee-script'
 
 gem 'local_time'
 gem 'rails_admin'
-gem 'remotipart', github: 'mshibuya/remotipart', require: false
+gem 'remotipart', git: 'https://github.com/mshibuya/remotipart', require: false
 
 group :production do
   gem 'aaf-secure_headers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,4 @@
 GIT
-  remote: git://github.com/mshibuya/remotipart.git
-  revision: cd653ddc43bb09767b8f2802d6e27b3e00ef992f
-  specs:
-    remotipart (1.3.1)
-
-GIT
   remote: https://github.com/guard/guard-rspec
   revision: 299561df951fe1d86275f19c4ffb6953e0ef7bc3
   branch: rails-5-support
@@ -13,6 +7,12 @@ GIT
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 3.5.0.beta, < 4.0)
+
+GIT
+  remote: https://github.com/mshibuya/remotipart
+  revision: cd653ddc43bb09767b8f2802d6e27b3e00ef992f
+  specs:
+    remotipart (1.3.1)
 
 GEM
   remote: https://rubygems.org/
@@ -74,12 +74,12 @@ GEM
     ast (2.3.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    brakeman (3.4.1)
-    builder (3.2.2)
+    brakeman (3.5.0)
+    builder (3.2.3)
     bullet (5.5.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.10.0)
-    capybara (2.11.0)
+    capybara (2.12.1)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -100,7 +100,7 @@ GEM
       safe_yaml (~> 1.0.0)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     docile (1.1.5)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -109,16 +109,16 @@ GEM
     factory_girl_rails (4.8.0)
       factory_girl (~> 4.8.0)
       railties (>= 3.0.0)
-    faker (1.7.1)
+    faker (1.7.3)
       i18n (~> 0.5)
-    ffi (1.9.14)
+    ffi (1.9.17)
     font-awesome-rails (4.7.0.1)
       railties (>= 3.2, < 5.1)
     formatador (0.2.5)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     god (0.13.7)
-    guard (2.14.0)
+    guard (2.14.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
       lumberjack (~> 1.0)
@@ -141,18 +141,18 @@ GEM
     haml (4.0.7)
       tilt
     hashdiff (0.3.2)
-    i18n (0.7.0)
+    i18n (0.8.0)
     jquery-rails (4.2.2)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
-    json (2.0.2)
+    json (2.0.3)
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
-    kramdown (1.13.1)
+    kramdown (1.13.2)
     libv8 (3.16.14.17)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -162,7 +162,7 @@ GEM
       coffee-rails
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    lumberjack (1.0.10)
+    lumberjack (1.0.11)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
@@ -175,15 +175,15 @@ GEM
     nenv (0.3.0)
     nested_form (0.3.2)
     nio4r (1.2.1)
-    nokogiri (1.7.0)
+    nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    parser (2.3.3.1)
+    parser (2.4.0.0)
       ast (~> 2.2)
     pdfkit (0.8.2)
-    poltergeist (1.12.0)
+    poltergeist (1.13.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
@@ -193,7 +193,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     public_suffix (2.0.5)
-    puma (3.6.2)
+    puma (3.7.0)
     rack (2.0.1)
     rack-pjax (1.0.0)
       nokogiri (~> 1.5)
@@ -243,7 +243,7 @@ GEM
     rainbow (2.2.1)
     rake (12.0.0)
     rb-fsevent (0.9.8)
-    rb-inotify (0.9.7)
+    rb-inotify (0.9.8)
       ffi (>= 0.5.0)
     ref (2.0.0)
     rmagick (2.16.0)
@@ -268,8 +268,8 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.46.0)
-      parser (>= 2.3.1.1, < 3.0)
+    rubocop (0.47.1)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
@@ -291,7 +291,7 @@ GEM
       rack
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
-    simplecov (0.12.0)
+    simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -314,12 +314,12 @@ GEM
     super-identity (0.1.0)
     temple (0.7.7)
     terminal-notifier-guard (1.7.0)
-    therubyracer (0.12.2)
-      libv8 (~> 3.16.14.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
       ref
     thor (0.19.4)
     thread_safe (0.3.5)
-    tilt (2.0.5)
+    tilt (2.0.6)
     timecop (0.8.1)
     torba (1.0.1)
       thor (~> 0.19.1)
@@ -330,7 +330,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.4)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.1.2)
+    unicode-display_width (1.1.3)
     uniform_notifier (1.10.0)
     useragent (0.16.8)
     valhammer (0.3.1)
@@ -345,7 +345,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    websocket-driver (0.6.4)
+    websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
     will_paginate (3.1.5)
@@ -402,4 +402,4 @@ DEPENDENCIES
   wkhtmltopdf-binary
 
 BUNDLED WITH
-   1.12.5
+   1.13.7

--- a/app/models/federation_attribute.rb
+++ b/app/models/federation_attribute.rb
@@ -34,9 +34,11 @@ class FederationAttribute < ApplicationRecord
                                   { id: primary_alias_id })
   end
 
+  # rubocop:disable Rails/SkipsModelValidations
   def sync_name
     update_attribute(:primary_alias_name, primary_alias.name)
   end
+  # rubocop:enable Rails/SkipsModelValidations
 
   def custom_label_method
     primary_alias_name

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,8 @@ module ValidatorService
     config.shib_rack.receiver = 'Authentication::SubjectReceiver'
     config.shib_rack.error_handler = 'Authentication::ErrorHandler'
 
-    app_config = YAML.load(Rails.root.join('config/validator_service.yml').read)
+    app_config_path = %w(config validator_service.yml)
+    app_config = YAML.safe_load(Rails.root.join(*app_config_path).read)
     config.validator_service = OpenStruct.new(app_config.deep_symbolize_keys)
 
     config.asset_host = config.validator_service.url_options[:base_url]

--- a/config/deploy.yml.dist
+++ b/config/deploy.yml.dist
@@ -1,3 +1,5 @@
 ---
 puma:
-  port: 3000
+  bind: tcp://localhost:3000
+  stdout: tmp/logs/puma-stdout.log
+  stderr: tmp/logs/puma-stderr.log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -7,7 +7,8 @@ Rails.application.configure do
 
   config.consider_all_requests_local = true
 
-  if Rails.root.join('tmp/caching-dev.txt').exist?
+  dev_cache = %w(tmp caching-dev.txt)
+  if Rails.root.join(*dev_cache).exist?
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -7,7 +7,8 @@ env = ENV.fetch('RAILS_ENV') { 'development' }
 preload_app!
 daemonize unless env == 'development'
 
-port puma_config['port']
+bind puma_config['bind']
+
 environment env
 workers 2
 threads 8, 32

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'yaml'
+
 config = YAML.load_file(File.expand_path('../deploy.yml', __FILE__))
 puma_config = config['puma']
 env = ENV.fetch('RAILS_ENV') { 'development' }

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Category, type: :model do
         regexp: '[a-zA-Z]+',
         regexp_triggers_failure: false
       )
-      second_attribute_value.update_attribute(:value, 123)
+      second_attribute_value.update(value: 123)
 
       expect(category.grouped_attributes(attribute_values)).to(
         eql(

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,7 +11,8 @@ require 'factory_girl_rails'
 
 ActiveRecord::Migration.maintain_test_schema!
 
-Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+supporting_files = %w(spec support ** *.rb)
+Dir[Rails.root.join(*supporting_files)].each { |f| require f }
 
 RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
The AAF wishes to use Unix sockets for ruby applications instead of having applications (potentially) bind to public interfaces.

The commit 0f4b7f5 directly underpins this need and is the key review-]able here.

I noted some out of date gems so have also patched for security as part of this PR.

*Do not* merge this PR yet. Co-ordination is required here with Ansible PR https://github.com/ausaccessfed/aaf-ansible/pull/418 and other rails application PR.