### PR TITLE
Use Redis for session storage instead of cookies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gem 'mysql2'
 gem 'rails', '>= 5.0.0', '< 5.1'
+gem 'redis-rails'
 
 gem 'aaf-lipstick'
 gem 'accession'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,7 +312,7 @@ GEM
     secure_headers (3.5.1)
       useragent
     shellany (0.0.1)
-    shib-rack (0.2.0)
+    shib-rack (0.3.0)
       rack
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,6 +251,23 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    redis (3.3.3)
+    redis-actionpack (5.0.1)
+      actionpack (>= 4.0, < 6)
+      redis-rack (>= 1, < 3)
+      redis-store (>= 1.1.0, < 1.4.0)
+    redis-activesupport (5.0.2)
+      activesupport (>= 3, < 6)
+      redis-store (~> 1.3.0)
+    redis-rack (2.0.2)
+      rack (>= 1.5, < 3)
+      redis-store (>= 1.2, < 1.4)
+    redis-rails (5.0.2)
+      redis-actionpack (>= 5.0, < 6)
+      redis-activesupport (>= 5.0, < 6)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.3.0)
+      redis (>= 2.2)
     ref (2.0.0)
     remotipart (1.3.1)
     rmagick (2.16.0)
@@ -390,6 +407,7 @@ DEPENDENCIES
   rails (>= 5.0.0, < 5.1)
   rails-controller-testing
   rails_admin
+  redis-rails
   rspec-rails (~> 3.5.0.beta4)
   rubocop
   sass-rails
@@ -409,4 +427,4 @@ DEPENDENCIES
   wkhtmltopdf-binary
 
 BUNDLED WITH
-   1.15.1
+   1.15.2

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,14 @@
 # frozen_string_literal: true
 
 Rails.application.config
-     .session_store :cookie_store, key: '_validator_service_session'
+     .session_store :redis_store,
+                    servers: [
+                      {
+                        host: 'localhost',
+                        port: 6379,
+                        db: 1,
+                        namespace: 'validator_session'
+                      }
+                    ],
+                    expire_after: 90.minutes,
+                    key: '_validator_session'


### PR DESCRIPTION
Fixes #139.

Waiting on https://github.com/ausaccessfed/shib-rack/pull/16 before review and merge, as I will update the gem here.