### PR TITLE
Use "Unknown Subject" if DN and CN are blank

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -52,10 +52,12 @@ class Subject < ApplicationRecord
   end
 
   def subject_name(attrs)
-    fn = FederationAttribute.find_by(internal_alias: :displayname)
-    return 'Unknown Subject' if fn.blank?
+    dn = FederationAttribute.find_by(internal_alias: :displayname).http_header
+    cn = FederationAttribute.find_by(internal_alias: :cn).http_header
 
-    attrs[fn.http_header]
+    return 'Unknown Subject' if attrs[dn].blank? && attrs[cn].blank?
+
+    attrs[dn].blank? ? attrs[cn] : attrs[dn]
   end
 
   def subject_mail(attrs)


### PR DESCRIPTION
Fixes #132.  Pre-existing Subjects with name values erred when null
values are passed in subsequent sessions.

This makes use of "Unknown Subject" since we don't want name attributes
to be required for a minimal viable session.