### PR TITLE
Manually set wkhtmltopdf binary location

### DIFF
--- a/config/initializers/pdfkit.rb
+++ b/config/initializers/pdfkit.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+PDFKit.configure do |config|
+  config.wkhtmltopdf = Bundler.which('wkhtmltopdf')
+end


### PR DESCRIPTION
The gem couldn't find the binary, because it was forking out a call to
`bundler exec which wkhtmltopdf`.  (We need `rbenv exec` prefixing).

This is a better method and fixes the error when trying to render PDF's.