### PR TITLE
Remove IdE integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development, :test do
   gem 'rails-controller-testing'
   gem 'rspec-rails', '~> 3.5.0.beta4'
   gem 'rubocop', require: false
+  gem 'rubocop-rspec', require: false
   gem 'shoulda-matchers'
   gem 'simplecov', require: false
   gem 'terminal-notifier-guard', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem 'rmagick', '~> 2.16'
 gem 'sass-rails', require: false
 gem 'shib-rack'
 gem 'slim-rails'
-gem 'super-identity'
 gem 'therubyracer', require: false
 gem 'torba-rails'
 gem 'uglifier', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,7 +346,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    super-identity (0.1.0)
     temple (0.8.1)
     terminal-notifier-guard (1.7.0)
     therubyracer (0.12.3)
@@ -427,7 +426,6 @@ DEPENDENCIES
   shoulda-matchers
   simplecov
   slim-rails
-  super-identity
   terminal-notifier-guard
   therubyracer
   timecop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,6 +306,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
+    rubocop-rspec (1.32.0)
+      rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     safe_yaml (1.0.5)
@@ -421,6 +423,7 @@ DEPENDENCIES
   rmagick (~> 2.16)
   rspec-rails (~> 3.5.0.beta4)
   rubocop
+  rubocop-rspec
   sass-rails
   shib-rack
   shoulda-matchers

--- a/config/validator_service.yml.dist
+++ b/config/validator_service.yml.dist
@@ -1,5 +1,10 @@
 ---
 environment_string: Development
+admins:
+  "shared_token_value":
+    - "urn:mace:aaf.edu.au:ide:internal:aaf-admin"
+  "shared_token_value2":
+    - "urn:mace:aaf.edu.au:ide:internal:aaf-admin"
 url_options:
   base_url: 'http://localhost:3000'
 secure_headers:

--- a/config/validator_service.yml.dist
+++ b/config/validator_service.yml.dist
@@ -1,11 +1,5 @@
 ---
 environment_string: Development
-ide:
-  host: ide.dev.aaf.edu.au
-  cert: config/api-client.crt
-  key: config/api-client.key
-  admin_entitlements:
-    - urn:mace:aaf.edu.au:ide:internal:aaf-admin
 url_options:
   base_url: 'http://localhost:3000'
 secure_headers:

--- a/lib/authentication/subject_receiver.rb
+++ b/lib/authentication/subject_receiver.rb
@@ -26,8 +26,9 @@ module Authentication
         subject = Subject.create_from_receiver(existing_attributes)
         Snapshot.create_from_receiver(subject, existing_attributes)
 
-        assign_entitlements(subject, [])
-
+        assign_entitlements(subject,
+                            Rails.application.config.validator_service
+          .admins.fetch(subject.shared_token.to_sym, []))
         subject
       end
     end

--- a/lib/authentication/subject_receiver.rb
+++ b/lib/authentication/subject_receiver.rb
@@ -5,7 +5,6 @@ require 'authentication/attribute_helpers'
 module Authentication
   class SubjectReceiver
     include ShibRack::DefaultReceiver
-    include SuperIdentity::Client
     include Rails.application.routes.url_helpers
 
     def receive(env)
@@ -27,10 +26,7 @@ module Authentication
         subject = Subject.create_from_receiver(existing_attributes)
         Snapshot.create_from_receiver(subject, existing_attributes)
 
-        assign_entitlements(
-          subject,
-          entitlements(subject.shared_token)
-        )
+        assign_entitlements(subject, [])
 
         subject
       end
@@ -47,10 +43,6 @@ module Authentication
       return redirect_to('/') unless Rails.env.production?
 
       redirect_to('/Shibboleth.sso/Logout?return=/')
-    end
-
-    def ide_config
-      Rails.application.config.validator_service.ide
     end
     # :nocov:
 

--- a/lib/authentication/subject_receiver.rb
+++ b/lib/authentication/subject_receiver.rb
@@ -26,9 +26,10 @@ module Authentication
         subject = Subject.create_from_receiver(existing_attributes)
         Snapshot.create_from_receiver(subject, existing_attributes)
 
-        assign_entitlements(subject,
-                            Rails.application.config.validator_service
-          .admins.fetch(subject.shared_token.to_sym, []))
+        admins = Rails.application.config.validator_service.admins
+        entitlements = admins.fetch(subject.shared_token.to_sym, [])
+        assign_entitlements(subject, entitlements)
+
         subject
       end
     end

--- a/spec/factories/api_subjects.rb
+++ b/spec/factories/api_subjects.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
   end
 
   trait :authorized do
-    transient { permission '*' }
+    transient { permission { '*' } }
 
     after(:create) do |api_subject, attrs|
       role = create :role

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :category do
-    name Faker::Commerce.department
-    enabled true
-    order 1
+    name { Faker::Commerce.department }
+    enabled { true }
+    order { 1 }
   end
 end

--- a/spec/factories/category_attributes.rb
+++ b/spec/factories/category_attributes.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :category_attribute do
-    presence false
-    category nil
-    federation_attribute nil
+    presence { false }
+    category { nil }
+    federation_attribute { nil }
   end
 end

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
     complete { true }
 
     trait :authorized do
-      transient { permission '*' }
+      transient { permission { '*' } }
 
       after(:create) do |subject, attrs|
         role = create :role
@@ -26,7 +26,7 @@ FactoryBot.define do
 
     # :nocov:
     trait :admin do
-      transient { permission 'app:validator:admin:*' }
+      transient { permission { 'app:validator:admin:*' } }
 
       after(:create) do |subject, attrs|
         role = create(

--- a/spec/lib/subject_receiver_spec.rb
+++ b/spec/lib/subject_receiver_spec.rb
@@ -5,15 +5,6 @@ require 'rails_helper'
 RSpec.describe Authentication::SubjectReceiver do
   let(:subject_receiver) { Authentication::SubjectReceiver.new }
 
-  let(:ide_config) do
-    {
-      host: 'ide.example.edu',
-      cert: 'spec/api.crt',
-      key: 'spec/api.key',
-      admin_entitlements: ['urn:mace:aaf.edu.au:ide:internal:aaf-admin']
-    }
-  end
-
   let(:attrs) do
     Authentication::AttributeHelpers
       .federation_attributes(attributes_for(:shib_env)[:env])
@@ -24,15 +15,10 @@ RSpec.describe Authentication::SubjectReceiver do
   end
 
   before do
-    allow(subject_receiver).to receive(:ide_config).and_return(ide_config)
-
     create_federation_attributes
 
     entitlement = 'urn:mace:aaf.edu.au:ide:internal:aaf-admin'
     FactoryBot.create(:role, entitlement: entitlement)
-
-    stub_ide(shared_token: attrs['HTTP_AUEDUPERSONSHAREDTOKEN'],
-             entitlements: [entitlement])
   end
 
   describe '#receive' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,6 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.include FactoryBot::Syntax::Methods
 
-  config.include SuperIdentity::TestStub
   config.include FederationAttributes
 
   %i[controller view request].each do |type|


### PR DESCRIPTION
Removes reliance on IdE and instead deploys a simple mapping of AEPST to Entitlement strings within the application config file.

Fixes #169.