### PR TITLE
AppConfig: fix typo (nil vs null)

### DIFF
--- a/config/validator_service.yml.dist
+++ b/config/validator_service.yml.dist
@@ -9,5 +9,5 @@ url_options:
   base_url: 'http://localhost:3000'
 secure_headers:
   csp:
-    report_uri: nil
+    report_uri: null
 time_zone: Australia/Brisbane


### PR DESCRIPTION
YAML nil value is null (nil gets parsed as string "nil").

https://yaml.org/type/null.html