### PR TITLE
Logout: fix logout on Rails 5.2

### DIFF
--- a/app/controllers/snapshots_controller.rb
+++ b/app/controllers/snapshots_controller.rb
@@ -13,7 +13,7 @@ class SnapshotsController < ApplicationController
 
     show_actions
 
-    request.env['rack.session'].clear
+    request.env['rack.session'].destroy
   end
 
   def latest

--- a/lib/authentication/subject_receiver.rb
+++ b/lib/authentication/subject_receiver.rb
@@ -40,7 +40,7 @@ module Authentication
 
     # :nocov:
     def logout(env)
-      env['rack.session'].clear
+      env['rack.session'].destroy
 
       return redirect_to('/') unless Rails.env.production?
 

--- a/lib/authentication/subject_receiver.rb
+++ b/lib/authentication/subject_receiver.rb
@@ -34,7 +34,12 @@ module Authentication
       end
     end
 
-    def finish(_env)
+    def finish(env)
+      url = env['rack.session']['return_url'].to_s
+      env['rack.session'].delete('return_url')
+
+      return redirect_to(url) if url.present?
+
       redirect_to(latest_snapshots_path)
     end
 

--- a/spec/lib/subject_receiver_spec.rb
+++ b/spec/lib/subject_receiver_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe Authentication::SubjectReceiver do
   end
 
   describe '#finish' do
-    let(:result) { subject_receiver.finish({}) }
+    let(:result) { subject_receiver.finish(rack_env) }
 
     it 'redirects to the latest snapshot after a successful login' do
       expect(result).to eql([302, { 'Location' => '/snapshots/latest' }, []])


### PR DESCRIPTION
ActionDispatch::Request::Session.clear stopped working on Rails 5.2 - session stays there.

Calling destroy instead works.

ActionDispatch::Request.reset_session also calls destroy, so that should be the right method to call:
https://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-reset_session

Fixes #181