### PR TITLE
Config: use correct key for session expiry

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -10,5 +10,5 @@ Rails.application.config
                         namespace: 'validator_session'
                       }
                     ],
-                    expire_in: 90.minutes,
+                    expire_after: 90.minutes,
                     key: '_validator_session'


### PR DESCRIPTION
As per https://github.com/redis-store/redis-rails
the correct key name is `expiry_after`.

When using `expire_in`, it does correctly set the Redis key expiry date,
but is ignored when constructing the cookie.

When using `expire_after`, the expiry is correctly applied to both
the Redis key and the session cookie.