### PR TITLE
Fix: add missing hash to script-src policy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
       rails (>= 5.0, < 7)
       remotipart (~> 1.3)
       sassc-rails (>= 1.3, < 3)
-    rails_admin_aaf_theme (0.1.3)
+    rails_admin_aaf_theme (0.1.4)
       aaf-lipstick
       rails (~> 5.0)
       secure_headers

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -49,6 +49,9 @@ SecureHeaders::Configuration.override(:rails_admin) do |config|
   config.csp[:connect_src] = ["'self'"]
   config.csp[:script_src] = config.csp[:script_src] + [
     "'unsafe-eval'",
+    "'sha256-47mKTaMaEn1L3m5DAz9muidMqw636xxw7EFAK/YnPdg='",
+    # sha256 of "t" to cover
+    # div.setAttribute( eventName, "t" );
     "'sha256-73+D8uQwNyLmkFjvaILshPLBcTjapyK9P5FGfkepYxE='",
     "'sha256-2IZ3eH4vQ4iO/yUXEJx3CWqGvsT1mFTk9j1WeznailE='"
     # <script>


### PR DESCRIPTION
Fix CSP violation reported on browser console for

    div.setAttribute( eventName, "t" );

- so add sha256 of "t" (47mKTaMaEn1L3m5DAz9muidMqw636xxw7EFAK/YnPdg=)