### PR TITLE
Fix: SubjectReceiver: use safe navigation for sharedToken

### DIFF
--- a/lib/authentication/subject_receiver.rb
+++ b/lib/authentication/subject_receiver.rb
@@ -27,7 +27,7 @@ module Authentication
         Snapshot.create_from_receiver(subject, existing_attributes)
 
         admins = Rails.application.config.validator_service.admins
-        entitlements = admins.fetch(subject.shared_token.to_sym, [])
+        entitlements = admins.fetch(subject.shared_token&.to_sym, [])
         assign_entitlements(subject, entitlements)
 
         subject


### PR DESCRIPTION
When sharedToken is null (possibly a misconfigured IdP), Validator Service blows up with an Internal Error, with stack trace pointing to the missing sharedToken value:

    NoMethodError (undefined method `to_sym' for nil:NilClass):

    lib/authentication/subject_receiver.rb:30:in `block in subject'
    lib/authentication/subject_receiver.rb:25:in `subject'
    lib/authentication/subject_receiver.rb:12:in `receive'

Fix this by using safe navigation - which results into the default empty set of permissions being used.

Given this is the Validator service to aid with IdP deployment, it should handle such misconfiguration gracefully.

All tests pass.